### PR TITLE
Fix ordered list counter issues in footnotes

### DIFF
--- a/src/content/log/01-markdown-style-guide.md
+++ b/src/content/log/01-markdown-style-guide.md
@@ -51,7 +51,9 @@ Ordered lists use numbers followed by a period and space:
 1. First item
 2. Second item
    1. Nested numbered item
-   2. Another nested item
+      1. You can use up to 3 nested layers
+      2. But don't use more please
+   2. Three should be more than enough
 
 ### Code Blocks
 

--- a/src/styles/markdown/footnotes.css
+++ b/src/styles/markdown/footnotes.css
@@ -5,7 +5,7 @@ div[data-markdown-content] a[data-footnote-ref] {
   @apply dark:text-mint-500 pl-0.5 underline-offset-2;
 }
 
-/* footnote section (page end) */
+/* footnote section (page end); counter see ol style -> ./list.css */
 div[data-markdown-content] section.footnotes h2 {
   @apply hidden;
 }
@@ -20,23 +20,8 @@ div[data-markdown-content] .footnotes::before {
   @apply bg-neutral-800;
 }
 
-div[data-markdown-content] section.footnotes ol {
-  @apply list-none pl-0;
-  counter-reset: 0;
-}
-
 div[data-markdown-content] section.footnotes ol li {
-  @apply flex;
-  counter-increment: list-item;
-}
-
-div[data-markdown-content] section.footnotes ol li::before {
-  content: counter(list-item) '.';
-  @apply text-neutral-500 dark:text-neutral-400;
-}
-
-div[data-markdown-content] section.footnotes p {
-  @apply block text-left break-all md:break-normal;
+  @apply flex flex-row break-all md:break-normal;
 }
 
 div[data-markdown-content] a[data-footnote-backref] {

--- a/src/styles/markdown/list.css
+++ b/src/styles/markdown/list.css
@@ -22,10 +22,6 @@ div[data-markdown-content] li:not(.task-list-item) {
   @apply ml-[3px];
 }
 
-div[data-markdown-content] li p {
-  @apply flex flex-row flex-wrap text-wrap;
-}
-
 div[data-markdown-content] ol {
   @apply list-inside;
   counter-reset: item;
@@ -38,7 +34,7 @@ div[data-markdown-content] ol li {
 
 div[data-markdown-content] ol li::before {
   content: counter(item) '.';
-  @apply mr-2 font-mono text-neutral-600 dark:text-neutral-400;
+  @apply shrink-0 pr-2 font-mono text-neutral-600 dark:text-neutral-400;
 }
 
 div[data-markdown-content] ol ol {
@@ -52,5 +48,19 @@ div[data-markdown-content] ol ol li {
 
 div[data-markdown-content] ol ol li::before {
   content: counter(item) '.' counter(subitem) '.';
+  @apply font-mono;
+}
+
+div[data-markdown-content] ol ol ol {
+  @apply ml-6;
+  counter-reset: subsubitem;
+}
+
+div[data-markdown-content] ol ol ol li {
+  counter-increment: subsubitem;
+}
+
+div[data-markdown-content] ol ol ol li::before {
+  content: counter(item) '.' counter(subitem) '.' counter(subsubitem) '.';
   @apply font-mono;
 }


### PR DESCRIPTION
Resolve issues with ordered list counters in footnotes by improving the CSS styles and ensuring proper nesting of list items.